### PR TITLE
Rb 3669

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ var paths = {
         'source/tryGoal/tryGoal_app.js',
         'source/agent.js',
         'source/tryGoal/component/tryGoalController.js',
+        'source/results/component/resultsController.js',
         'source/goalList/**/*.js',
         'source/mainController.js',
         'source/directives/**/*.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,14 +152,13 @@ gulp.task('default', ['dev']);
 
 
 //BrowserSync
-gulp.task('js-watch', ['build'], function (done) {
+gulp.task('build-and-reload', ['build'], function (done) {
 	browserSync.reload();
 	done();
 });
 
 
 gulp.task('watchandrefresh', ['build'], function () {
-
 	// Serve files from the root of this project
 	browserSync.init({
 		proxy: "localhost:3051",
@@ -167,7 +166,7 @@ gulp.task('watchandrefresh', ['build'], function () {
 		notify: true
 	});
 
-	gulp.watch('source/**/*.js', ['js-watch']);
+	gulp.watch(['source/**/*.js', 'source/**/*.html'], ['build-and-reload']);
 });
 
 gulp.task('watch-less', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,6 +126,8 @@ gulp.task('copy-html', function() {
         .pipe(gulp.dest('dist/goalList'));
     gulp.src(['source/main.html'])
         .pipe(gulp.dest('dist'));
+    gulp.src(['source/results/component/results.html'])
+        .pipe(gulp.dest('dist/results/'));
 	gulp.src(['source/angular-semantic-ui.min.js'])
 			.pipe(gulp.dest('dist'));
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": "8.9.3"
   },
   "dependencies": {
+    "del": "^3.0.0",
     "ejs": "2.5.x",
     "express": "4.16.x",
     "gulp-concat": "2.4.x",
@@ -23,9 +24,9 @@
     "gulp-sourcemaps": "1.6.x",
     "gulp-uglify": "3.0.x",
     "gulp-util": "3.0.x",
+    "karma": "2.x.x",
     "run-sequence": "1.2.x",
-    "superagent": "3.8.x",
-    "karma": "2.x.x"
+    "superagent": "3.8.x"
   },
   "devDependencies": {
     "angular": "1.4.8",

--- a/source/agent.js
+++ b/source/agent.js
@@ -64,6 +64,7 @@ agentApp.config(['$stateProvider', '$urlRouterProvider', '$httpProvider', functi
             url: '/results',
             templateUrl: '/applications/results/results.html',
             controller: 'ResultsController',
+            params: { goalInfo: null, responseData: null }
         });
 
 

--- a/source/agent.js
+++ b/source/agent.js
@@ -1,4 +1,4 @@
-var agentApp = angular.module('rbAgent', ['ui.router', 'rbApp.tryGoal', 'rbApp.tryGoal.service', 'ui.bootstrap', 'semantic-ui', 'pluralNumbers', 'datePicker']);
+var agentApp = angular.module('rbAgent', ['ui.router', 'rbApp.tryGoal', 'rbApp.tryGoal.service', 'ui.bootstrap', 'semantic-ui', 'pluralNumbers', 'datePicker', 'rbApp.results']);
 
 agentApp.value('agentMemory',
     {
@@ -64,13 +64,7 @@ agentApp.config(['$stateProvider', '$urlRouterProvider', '$httpProvider', functi
             url: '/results',
             templateUrl: '/applications/results/results.html',
             controller: 'ResultsController',
-            resolve: {
-                config: ['ConfigAPI', '$rootScope', function(ConfigAPI, $rootScope) {
-                    return ConfigAPI.config({ id: $rootScope.id });
-                }]
-            },
-            params: { goalInfo: null, id: null }
-    });;
+        });
 
 
     $httpProvider.interceptors.push('agentHttpInterceptor');

--- a/source/agent.js
+++ b/source/agent.js
@@ -59,7 +59,19 @@ agentApp.config(['$stateProvider', '$urlRouterProvider', '$httpProvider', functi
                 }]
             },
             params: { goalInfo: null, id: null }
-        });
+        })
+        .state('main.results', {
+            url: '/results',
+            templateUrl: '/applications/results/results.html',
+            controller: 'ResultsController',
+            resolve: {
+                config: ['ConfigAPI', '$rootScope', function(ConfigAPI, $rootScope) {
+                    return ConfigAPI.config({ id: $rootScope.id });
+                }]
+            },
+            params: { goalInfo: null, id: null }
+    });;
+
 
     $httpProvider.interceptors.push('agentHttpInterceptor');
 }]);

--- a/source/agent.js
+++ b/source/agent.js
@@ -68,8 +68,7 @@ agentApp.config(['$stateProvider', '$urlRouterProvider', '$httpProvider', functi
                 config: ['ConfigAPI', '$rootScope', function(ConfigAPI, $rootScope) {
                     return ConfigAPI.config({ id: $rootScope.id });
                 }]
-            },
-            params: { goalInfo: null, responseData: null }
+            }
         });
 
 

--- a/source/agent.js
+++ b/source/agent.js
@@ -64,6 +64,11 @@ agentApp.config(['$stateProvider', '$urlRouterProvider', '$httpProvider', functi
             url: '/results',
             templateUrl: '/applications/results/results.html',
             controller: 'ResultsController',
+            resolve: {
+                config: ['ConfigAPI', '$rootScope', function(ConfigAPI, $rootScope) {
+                    return ConfigAPI.config({ id: $rootScope.id });
+                }]
+            },
             params: { goalInfo: null, responseData: null }
         });
 

--- a/source/agent.js
+++ b/source/agent.js
@@ -61,7 +61,7 @@ agentApp.config(['$stateProvider', '$urlRouterProvider', '$httpProvider', functi
             params: { goalInfo: null, id: null }
         })
         .state('main.results', {
-            url: '/results',
+            url: '/results/:sid',
             templateUrl: '/applications/results/results.html',
             controller: 'ResultsController',
             resolve: {

--- a/source/results/component/results.html
+++ b/source/results/component/results.html
@@ -1,0 +1,1 @@
+<h1>Results page</h1>

--- a/source/results/component/results.html
+++ b/source/results/component/results.html
@@ -16,7 +16,8 @@
             </div>
         </li>
     </ul>
-</div>
-<div class="result-download">
-    <a class="btn btn-download btn-primary" href="#TODO">Download PDF</a>
+
+    <div class="result-download">
+        <a class="btn btn-download btn-primary" href="#TODO">Download PDF</a>
+    </div>
 </div>

--- a/source/results/component/results.html
+++ b/source/results/component/results.html
@@ -17,3 +17,6 @@
         </li>
     </ul>
 </div>
+<div class="result-download">
+    <a class="btn btn-download btn-primary" href="#TODO">Download PDF</a>
+</div>

--- a/source/results/component/results.html
+++ b/source/results/component/results.html
@@ -1,1 +1,20 @@
 
+<div class="result clearfix" ng-if="display === 'result'">
+    <p class="results-title">Your Results</p>
+    <ul class="results-list">
+        <li class="result" ng-repeat="response in goalResults">
+            <span>{{response.text}}</span>
+            <span class="result-cf" ng-hide="config.uiSettings.hideCF">{{response.cf}}%</span>
+            <a ng-show="config.showEvidence" target="_blank" ng-href="/applications/components/rainbird-analysis-ui/whyAnalysis.html?id={{response.factID}}?api={{yolandaUrl}}">
+                <span class="ui icon" data-tooltip="Show Evidence Tree" data-inverted="">
+                    <i class="why-analysis-icon result-analysis fa fa-info-circle">
+                    </i>
+                </span>
+            </a>
+            <div ng-repeat="meta in response.meta.en">
+                <div class="markdown-metadata" ng-if="meta.dataType === 'md'" markdown-to-html="meta.data"></div>
+                <div class="text-metadata" ng-if="meta.dataType === 'text'">{{meta.data}}</div>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/source/results/component/results.html
+++ b/source/results/component/results.html
@@ -1,1 +1,1 @@
-<h1>Results page</h1>
+

--- a/source/results/component/results.html
+++ b/source/results/component/results.html
@@ -1,5 +1,4 @@
-
-<div class="result clearfix" ng-if="display === 'result'">
+<div class="result clearfix">
     <p class="results-title">Your Results</p>
     <ul class="results-list">
         <li class="result" ng-repeat="response in goalResults">

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -4,7 +4,7 @@ angular.module('rbApp.results', [])
             controller: 'ResultsController',
             restrict: 'E',
             scope: {
-                responseData: '=responseData',
+                resultData: '=resultData',
                 goalInfo: '=goalInfo',
                 config: '=config'
             },
@@ -18,11 +18,11 @@ angular.module('rbApp.results', [])
     .controller('ResultsController', ['$scope', '$stateParams', 'ApiConfig',
         function ($scope, $stateParams, ApiConfig) {
 
-            function setResponses(responseData, goalInfo) {
+            function setResponses(resultData, goalInfo) {
                 $scope.yolandaUrl = ApiConfig.getConfig().url;
-                $scope.sid = responseData.sid;
+                $scope.sid = resultData.sid;
                 $scope.goalResults = [];
-                responseData.result.forEach(function (element) {
+                resultData.result.forEach(function (element) {
                     var resultText = (goalInfo.goalText ? goalInfo.goalText : goalInfo.text);
 
                     var metaData = element.objectMetadata ? element.objectMetadata : '';
@@ -52,15 +52,15 @@ angular.module('rbApp.results', [])
                     // #TODO: fetch these from the API endpoint
                     // Do we need to concern ourselves with the config.showEvidence config, which currently is defaulted to false if not set as part of the directive?
                     // At present it's only used to toggle the (i) which links one to the evidence tree page.
-                    var responseData = {"result":[{"objectMetadata":{},"subjectMetadata":{},"object":"Bob","subject":"Bob","factID":"WA:KF:db6bf9201785db2cf299b63eedfa4e96aa146af7736d1e09ac78164bb0cb8a52","relationship":"has name","relationshipType":"has name","certainty":100}],"stats":{"getDBFact":{"calls":1,"items":1,"ms":4},"callDatasource":{"calls":0,"ms":0},"ensureCache":{"ms":3},"setDBFact":{"calls":0,"ms":0},"totalMS":44,"approxEngineMS":37,"totalConditionCount":0,"invocationStartTime":1547634008100},"sid":"6ce9d77c-6427-4f2b-8c60-1cf3fea1a3a5"};
+                    var resultData = {"result":[{"objectMetadata":{},"subjectMetadata":{},"object":"Bob","subject":"Bob","factID":"WA:KF:db6bf9201785db2cf299b63eedfa4e96aa146af7736d1e09ac78164bb0cb8a52","relationship":"has name","relationshipType":"has name","certainty":100}],"stats":{"getDBFact":{"calls":1,"items":1,"ms":4},"callDatasource":{"calls":0,"ms":0},"ensureCache":{"ms":3},"setDBFact":{"calls":0,"ms":0},"totalMS":44,"approxEngineMS":37,"totalConditionCount":0,"invocationStartTime":1547634008100},"sid":"6ce9d77c-6427-4f2b-8c60-1cf3fea1a3a5"};
                     var goalInfo = {"goalId":{"type":"Buffer","data":[169,47,184,72,177,181,65,23,133,19,88,46,74,131,201,207]},"contextId":"","questionText":"Is named","answerText":"%S is called %O","subject":"Person","subjectInstance":"Bob","relationship":"has name","object":"Name","objectInstance":null,"_id":"a92fb848-b1b5-4117-8513-582e4a83c9cf","description":"Is named","text":"%S is called %O","rel":"has name","$$hashKey":"object:15"};
                     console.log(sid);
-                    setResponses(responseData, goalInfo);
+                    setResponses(resultData, goalInfo);
                 }
             }
 
             this.$postLink = function () {
-                setResponses($scope.responseData, $scope.goalInfo);
+                setResponses($scope.resultData, $scope.goalInfo);
             };
             init();
         }]);

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -20,6 +20,7 @@ angular.module('rbApp.results', [])
 
             function setResponses(responseData, goalInfo) {
                 $scope.yolandaUrl = ApiConfig.getConfig().url;
+                $scope.sid = responseData.sid;
                 $scope.goalResults = [];
                 responseData.result.forEach(function (element) {
                     var resultText = (goalInfo.goalText ? goalInfo.goalText : goalInfo.text);
@@ -49,6 +50,8 @@ angular.module('rbApp.results', [])
                 var sid = $stateParams.sid;
                 if (sid) {
                     // #TODO: fetch these from the API endpoint
+                    // Do we need to concern ourselves with the config.showEvidence config, which currently is defaulted to false if not set as part of the directive?
+                    // At present it's only used to toggle the (i) which links one to the evidence tree page.
                     var responseData = {"result":[{"objectMetadata":{},"subjectMetadata":{},"object":"Bob","subject":"Bob","factID":"WA:KF:db6bf9201785db2cf299b63eedfa4e96aa146af7736d1e09ac78164bb0cb8a52","relationship":"has name","relationshipType":"has name","certainty":100}],"stats":{"getDBFact":{"calls":1,"items":1,"ms":4},"callDatasource":{"calls":0,"ms":0},"ensureCache":{"ms":3},"setDBFact":{"calls":0,"ms":0},"totalMS":44,"approxEngineMS":37,"totalConditionCount":0,"invocationStartTime":1547634008100},"sid":"6ce9d77c-6427-4f2b-8c60-1cf3fea1a3a5"};
                     var goalInfo = {"goalId":{"type":"Buffer","data":[169,47,184,72,177,181,65,23,133,19,88,46,74,131,201,207]},"contextId":"","questionText":"Is named","answerText":"%S is called %O","subject":"Person","subjectInstance":"Bob","relationship":"has name","object":"Name","objectInstance":null,"_id":"a92fb848-b1b5-4117-8513-582e4a83c9cf","description":"Is named","text":"%S is called %O","rel":"has name","$$hashKey":"object:15"};
                     console.log(sid);

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -11,7 +11,7 @@ angular.module('rbApp.results', [])
             templateUrl: '/applications/results/results.html',
             link: function (scope, element, attrs, controller) {
                 scope.config = scope.config || {showEvidence: false};
-                controller.$postLink();
+                controller.init();
             }
         };
     })
@@ -24,7 +24,6 @@ angular.module('rbApp.results', [])
                 $scope.goalResults = [];
                 resultData.result.forEach(function (element) {
                     var resultText = (goalInfo.goalText ? goalInfo.goalText : goalInfo.text);
-
                     var metaData = element.objectMetadata ? element.objectMetadata : '';
 
                     resultText = resultText.replace(/%O/g, element.object);
@@ -54,13 +53,11 @@ angular.module('rbApp.results', [])
                     // At present it's only used to toggle the (i) which links one to the evidence tree page.
                     var resultData = {"result":[{"objectMetadata":{},"subjectMetadata":{},"object":"Bob","subject":"Bob","factID":"WA:KF:db6bf9201785db2cf299b63eedfa4e96aa146af7736d1e09ac78164bb0cb8a52","relationship":"has name","relationshipType":"has name","certainty":100}],"stats":{"getDBFact":{"calls":1,"items":1,"ms":4},"callDatasource":{"calls":0,"ms":0},"ensureCache":{"ms":3},"setDBFact":{"calls":0,"ms":0},"totalMS":44,"approxEngineMS":37,"totalConditionCount":0,"invocationStartTime":1547634008100},"sid":"6ce9d77c-6427-4f2b-8c60-1cf3fea1a3a5"};
                     var goalInfo = {"goalId":{"type":"Buffer","data":[169,47,184,72,177,181,65,23,133,19,88,46,74,131,201,207]},"contextId":"","questionText":"Is named","answerText":"%S is called %O","subject":"Person","subjectInstance":"Bob","relationship":"has name","object":"Name","objectInstance":null,"_id":"a92fb848-b1b5-4117-8513-582e4a83c9cf","description":"Is named","text":"%S is called %O","rel":"has name","$$hashKey":"object:15"};
-                    console.log(sid);
                     setResponses(resultData, goalInfo);
+                } else if ($scope.resultData && $scope.goalInfo) {
+                    setResponses($scope.resultData, $scope.goalInfo);
                 }
             }
-
-            this.$postLink = function () {
-                setResponses($scope.resultData, $scope.goalInfo);
-            };
             init();
+            this.init = init;
         }]);

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -1,0 +1,5 @@
+angular.module('rbApp.results')
+.controller('ResultsController', ['$scope',
+function($scope) {
+    
+}]);

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -10,7 +10,6 @@ angular.module('rbApp.results', [])
             },
             templateUrl: '/applications/results/results.html',
             link: function (scope, element, attrs, controller) {
-                scope.config = scope.config || {showEvidence: false};
                 controller.init();
             }
         };

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -5,27 +5,24 @@ angular.module('rbApp.results', [])
             restrict: 'E',
             scope: {
                 responseData: '=responseData',
-                goalInfo: '=goalInfo'
+                goalInfo: '=goalInfo',
+                config: '=config'
             },
             templateUrl: '/applications/results/results.html',
             link: function (scope, element, attrs, controller) {
-                scope.config = {showEvidence: false};
-                controller.$postLink(scope.responseData);
+                scope.config = scope.config || {showEvidence: false};
+                controller.$postLink();
             }
         };
     })
     .controller('ResultsController', ['$scope', '$stateParams', 'ApiConfig',
         function ($scope, $stateParams, ApiConfig) {
-            $scope.response = {};
 
-            function setResponses(responseData) {
+            function setResponses(responseData, goalInfo) {
                 $scope.yolandaUrl = ApiConfig.getConfig().url;
                 $scope.goalResults = [];
-                $scope.response = {};
-                $scope.goalInfo;
-                $scope.responseData;
                 responseData.result.forEach(function (element) {
-                    var resultText = ($scope.goalInfo.goalText ? $scope.goalInfo.goalText : $scope.goalInfo.text);
+                    var resultText = (goalInfo.goalText ? goalInfo.goalText : goalInfo.text);
 
                     var metaData = element.objectMetadata ? element.objectMetadata : '';
 
@@ -49,17 +46,18 @@ angular.module('rbApp.results', [])
             }
 
             function init() {
-                var responseData = $stateParams.responseData;
-                var goalInfo = $stateParams.goalInfo;
-
-                if (responseData && goalInfo) {
-                    $scope.goalInfo = goalInfo;
+                var sid = $stateParams.sid;
+                if (sid) {
+                    // #TODO: fetch these from the API endpoint
+                    var responseData = {"result":[{"objectMetadata":{},"subjectMetadata":{},"object":"Bob","subject":"Bob","factID":"WA:KF:db6bf9201785db2cf299b63eedfa4e96aa146af7736d1e09ac78164bb0cb8a52","relationship":"has name","relationshipType":"has name","certainty":100}],"stats":{"getDBFact":{"calls":1,"items":1,"ms":4},"callDatasource":{"calls":0,"ms":0},"ensureCache":{"ms":3},"setDBFact":{"calls":0,"ms":0},"totalMS":44,"approxEngineMS":37,"totalConditionCount":0,"invocationStartTime":1547634008100},"sid":"6ce9d77c-6427-4f2b-8c60-1cf3fea1a3a5"};
+                    var goalInfo = {"goalId":{"type":"Buffer","data":[169,47,184,72,177,181,65,23,133,19,88,46,74,131,201,207]},"contextId":"","questionText":"Is named","answerText":"%S is called %O","subject":"Person","subjectInstance":"Bob","relationship":"has name","object":"Name","objectInstance":null,"_id":"a92fb848-b1b5-4117-8513-582e4a83c9cf","description":"Is named","text":"%S is called %O","rel":"has name","$$hashKey":"object:15"};
+                    console.log(sid);
                     setResponses(responseData, goalInfo);
                 }
             }
 
             this.$postLink = function () {
-                setResponses($scope.responseData);
+                setResponses($scope.responseData, $scope.goalInfo);
             };
-            // init();
+            init();
         }]);

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -1,4 +1,46 @@
 angular.module('rbApp.results', [])
-.controller('ResultsController', ['$scope', function($scope) {
+.controller('ResultsController', ['$scope', '$stateParams', function($scope, $stateParams) {
+    $scope.goalResults = [];
+    $scope.response = {};
     
+    function setResponses(responseData) {
+        $scope.goalResults = [];
+        $scope.response = {};
+        $scope.goalInfo;
+        responseData.result.forEach(function(element) {
+            var resultText = ($scope.goalInfo.goalText ? $scope.goalInfo.goalText : $scope.goalInfo.text);
+
+            var metaData = element.objectMetadata ? element.objectMetadata : '';
+
+            resultText = resultText.replace(/%O/g, element.object);
+            resultText = resultText.replace(/%R/g, element.relationship);
+            resultText = resultText.replace(/%S/g, element.subject);
+            resultText = resultText.replace(/%C/g, element.certainty);
+
+            if ($scope.config.showEvidence) {
+                $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData, factID: element.factID });
+            } else {
+                $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData});
+            }
+        });
+        $scope.display = 'result';
+
+        if ($scope.tryGoal){
+            // focusElementById('reset');
+        } else {
+            // focusElementById('done');
+        }
+    }
+    
+    function init() {
+        var responseData = $stateParams.responseData;
+        var goalInfo = $stateParams.goalInfo;
+        $scope.goalInfo = goalInfo;
+
+        if (responseData && goalInfo) {
+            setResponses(responseData, goalInfo);
+        }
+    }
+    
+    init();
 }]);

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -1,5 +1,4 @@
-angular.module('rbApp.results')
-.controller('ResultsController', ['$scope',
-function($scope) {
+angular.module('rbApp.results', [])
+.controller('ResultsController', ['$scope', function($scope) {
     
 }]);

--- a/source/results/component/resultsController.js
+++ b/source/results/component/resultsController.js
@@ -1,46 +1,65 @@
 angular.module('rbApp.results', [])
-.controller('ResultsController', ['$scope', '$stateParams', function($scope, $stateParams) {
-    $scope.goalResults = [];
-    $scope.response = {};
-    
-    function setResponses(responseData) {
-        $scope.goalResults = [];
-        $scope.response = {};
-        $scope.goalInfo;
-        responseData.result.forEach(function(element) {
-            var resultText = ($scope.goalInfo.goalText ? $scope.goalInfo.goalText : $scope.goalInfo.text);
-
-            var metaData = element.objectMetadata ? element.objectMetadata : '';
-
-            resultText = resultText.replace(/%O/g, element.object);
-            resultText = resultText.replace(/%R/g, element.relationship);
-            resultText = resultText.replace(/%S/g, element.subject);
-            resultText = resultText.replace(/%C/g, element.certainty);
-
-            if ($scope.config.showEvidence) {
-                $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData, factID: element.factID });
-            } else {
-                $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData});
+    .directive('results', function () {
+        return {
+            controller: 'ResultsController',
+            restrict: 'E',
+            scope: {
+                responseData: '=responseData',
+                goalInfo: '=goalInfo'
+            },
+            templateUrl: '/applications/results/results.html',
+            link: function (scope, element, attrs, controller) {
+                scope.config = {showEvidence: false};
+                controller.$postLink(scope.responseData);
             }
-        });
-        $scope.display = 'result';
+        };
+    })
+    .controller('ResultsController', ['$scope', '$stateParams', 'ApiConfig',
+        function ($scope, $stateParams, ApiConfig) {
+            $scope.response = {};
 
-        if ($scope.tryGoal){
-            // focusElementById('reset');
-        } else {
-            // focusElementById('done');
-        }
-    }
-    
-    function init() {
-        var responseData = $stateParams.responseData;
-        var goalInfo = $stateParams.goalInfo;
-        $scope.goalInfo = goalInfo;
+            function setResponses(responseData) {
+                $scope.yolandaUrl = ApiConfig.getConfig().url;
+                $scope.goalResults = [];
+                $scope.response = {};
+                $scope.goalInfo;
+                $scope.responseData;
+                responseData.result.forEach(function (element) {
+                    var resultText = ($scope.goalInfo.goalText ? $scope.goalInfo.goalText : $scope.goalInfo.text);
 
-        if (responseData && goalInfo) {
-            setResponses(responseData, goalInfo);
-        }
-    }
-    
-    init();
-}]);
+                    var metaData = element.objectMetadata ? element.objectMetadata : '';
+
+                    resultText = resultText.replace(/%O/g, element.object);
+                    resultText = resultText.replace(/%R/g, element.relationship);
+                    resultText = resultText.replace(/%S/g, element.subject);
+                    resultText = resultText.replace(/%C/g, element.certainty);
+
+                    if ($scope.config.showEvidence) {
+                        $scope.goalResults.push({
+                            text: resultText,
+                            cf: element.certainty,
+                            meta: metaData,
+                            factID: element.factID
+                        });
+                    } else {
+                        $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData});
+                    }
+                });
+                $scope.display = 'result';
+            }
+
+            function init() {
+                var responseData = $stateParams.responseData;
+                var goalInfo = $stateParams.goalInfo;
+
+                if (responseData && goalInfo) {
+                    $scope.goalInfo = goalInfo;
+                    setResponses(responseData, goalInfo);
+                }
+            }
+
+            this.$postLink = function () {
+                setResponses($scope.responseData);
+            };
+            // init();
+        }]);

--- a/source/results/component/resultsSpec.js
+++ b/source/results/component/resultsSpec.js
@@ -1,0 +1,3 @@
+describe('Results controller', function() {
+
+});

--- a/source/styles/agent-content-style.less
+++ b/source/styles/agent-content-style.less
@@ -105,6 +105,10 @@
     .result-buttons {
         text-align: right;
     }
+
+    .result-download {
+      text-align: center;
+    }
 }
 .agent-content .result {
     margin: @spacing*2 @spacing;

--- a/source/styles/forms.less
+++ b/source/styles/forms.less
@@ -172,6 +172,11 @@ input[type="range"] {
     background-color: #bdc3c7;
 }
 
+.btn-download {
+  -webkit-appearance: none;
+  width: auto;
+}
+
 .btn-default:hover, .btn-default:focus, .btn-default:active, .btn-default.active, .open .dropdown-toggle.btn-default {
   color: white;
   background-color: #cacfd2;

--- a/source/tryGoal/component/shared/tryGoalBody.html
+++ b/source/tryGoal/component/shared/tryGoalBody.html
@@ -10,7 +10,7 @@
     </div>
 </div>
 <div class="result clearfix" ng-if="display === 'result'">
-    <results response-data="responseData" goal-info="goalInfo" config="config"></results>
+    <results result-data="resultData" goal-info="goalInfo" config="config"></results>
 </div>
 
 <div ng-if="display === 'end'" class="clearfix">

--- a/source/tryGoal/component/shared/tryGoalBody.html
+++ b/source/tryGoal/component/shared/tryGoalBody.html
@@ -1,3 +1,4 @@
+{{goalInfo | json}}
 <div ng-if="display === 'init data'" class="clearfix">
     <p class="rb-note-default">Tell me more...</p>
     <div class="col-sm-12">

--- a/source/tryGoal/component/shared/tryGoalBody.html
+++ b/source/tryGoal/component/shared/tryGoalBody.html
@@ -10,7 +10,7 @@
     </div>
 </div>
 <div class="result clearfix" ng-if="display === 'result'">
-    <results response-data="responseData" goal-info="goalInfo"></results>
+    <results response-data="responseData" goal-info="goalInfo" config="config"></results>
 </div>
 
 <div ng-if="display === 'end'" class="clearfix">

--- a/source/tryGoal/component/shared/tryGoalBody.html
+++ b/source/tryGoal/component/shared/tryGoalBody.html
@@ -1,4 +1,3 @@
-{{goalInfo | json}}
 <div ng-if="display === 'init data'" class="clearfix">
     <p class="rb-note-default">Tell me more...</p>
     <div class="col-sm-12">
@@ -11,23 +10,7 @@
     </div>
 </div>
 <div class="result clearfix" ng-if="display === 'result'">
-    <p class="results-title">Your Results</p>
-    <ul class="results-list">
-        <li class="result" ng-repeat="response in goalResults">
-            <span>{{response.text}}</span>
-            <span class="result-cf" ng-hide="config.uiSettings.hideCF">{{response.cf}}%</span>
-            <a ng-show="config.showEvidence" target="_blank" ng-href="/applications/components/rainbird-analysis-ui/whyAnalysis.html?id={{response.factID}}?api={{yolandaUrl}}">
-                <span class="ui icon" data-tooltip="Show Evidence Tree" data-inverted="">
-                    <i class="why-analysis-icon result-analysis fa fa-info-circle">
-                    </i>
-                </span>
-            </a>
-            <div ng-repeat="meta in response.meta.en">
-                <div class="markdown-metadata" ng-if="meta.dataType === 'md'" markdown-to-html="meta.data"></div>
-                <div class="text-metadata" ng-if="meta.dataType === 'text'">{{meta.data}}</div>
-            </div>
-        </li>
-    </ul>
+    <results response-data="responseData" goal-info="goalInfo"></results>
 </div>
 
 <div ng-if="display === 'end'" class="clearfix">

--- a/source/tryGoal/component/tryGoalController.js
+++ b/source/tryGoal/component/tryGoalController.js
@@ -8,6 +8,8 @@ function($scope, agentMemory, $compile, $stateParams, config, GoalAPI, ConfigAPI
     $scope.otherOption = {value: '(other - not listed)'};
     $scope.yolandaUrl = ApiConfig.getConfig().url;
     $scope.tryGoal = agentMemory.tryGoal;
+    $scope.response;
+    $scope.responseData;
 
     $scope.updateAlias = function() {
         sessionId = null;
@@ -222,37 +224,13 @@ function($scope, agentMemory, $compile, $stateParams, config, GoalAPI, ConfigAPI
             }
 
         } else if (response.result && angular.isArray(response.result) && response.result.length > 0) {
-            $state.go('main.results', {
-                goalInfo: $scope.goalInfo,
-                responseData: response
-            }, {
-                location: 'replace'
-            });
-            // $scope.goalResults = [];
-            // $scope.response = {};
-            // response.result.forEach(function(element) {
-            //     var resultText = ($scope.goalInfo.goalText ? $scope.goalInfo.goalText : $scope.goalInfo.text);
-            //
-            //     var metaData = element.objectMetadata ? element.objectMetadata : '';
-            //
-            //     resultText = resultText.replace(/%O/g, element.object);
-            //     resultText = resultText.replace(/%R/g, element.relationship);
-            //     resultText = resultText.replace(/%S/g, element.subject);
-            //     resultText = resultText.replace(/%C/g, element.certainty);
-            //
-            //     if ($scope.config.showEvidence) {
-            //         $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData, factID: element.factID });
-            //     } else {
-            //         $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData});
-            //     }
-            // });
-            // $scope.display = 'result';
-            //
-            // if ($scope.tryGoal){
-            //     focusElementById('reset');
-            // } else {
-            //     focusElementById('done');
-            // }
+            $scope.responseData = response;
+            $scope.display = 'result';
+            if ($scope.tryGoal){
+                focusElementById('reset');
+            } else {
+                focusElementById('done');
+            }
 
         } else if (angular.isArray(response.result)) {
             $scope.display = 'end';

--- a/source/tryGoal/component/tryGoalController.js
+++ b/source/tryGoal/component/tryGoalController.js
@@ -8,7 +8,6 @@ function($scope, agentMemory, $compile, $stateParams, config, GoalAPI, ConfigAPI
     $scope.otherOption = {value: '(other - not listed)'};
     $scope.yolandaUrl = ApiConfig.getConfig().url;
     $scope.tryGoal = agentMemory.tryGoal;
-    $scope.response;
     $scope.resultData;
 
     $scope.updateAlias = function() {

--- a/source/tryGoal/component/tryGoalController.js
+++ b/source/tryGoal/component/tryGoalController.js
@@ -9,7 +9,7 @@ function($scope, agentMemory, $compile, $stateParams, config, GoalAPI, ConfigAPI
     $scope.yolandaUrl = ApiConfig.getConfig().url;
     $scope.tryGoal = agentMemory.tryGoal;
     $scope.response;
-    $scope.responseData;
+    $scope.resultData;
 
     $scope.updateAlias = function() {
         sessionId = null;
@@ -224,7 +224,7 @@ function($scope, agentMemory, $compile, $stateParams, config, GoalAPI, ConfigAPI
             }
 
         } else if (response.result && angular.isArray(response.result) && response.result.length > 0) {
-            $scope.responseData = response;
+            $scope.resultData = response;
             $scope.display = 'result';
             if ($scope.tryGoal){
                 focusElementById('reset');

--- a/source/tryGoal/component/tryGoalController.js
+++ b/source/tryGoal/component/tryGoalController.js
@@ -222,31 +222,37 @@ function($scope, agentMemory, $compile, $stateParams, config, GoalAPI, ConfigAPI
             }
 
         } else if (response.result && angular.isArray(response.result) && response.result.length > 0) {
-            $scope.goalResults = [];
-            $scope.response = {};
-            response.result.forEach(function(element) {
-                var resultText = ($scope.goalInfo.goalText ? $scope.goalInfo.goalText : $scope.goalInfo.text);
-
-                var metaData = element.objectMetadata ? element.objectMetadata : '';
-
-                resultText = resultText.replace(/%O/g, element.object);
-                resultText = resultText.replace(/%R/g, element.relationship);
-                resultText = resultText.replace(/%S/g, element.subject);
-                resultText = resultText.replace(/%C/g, element.certainty);
-
-                if ($scope.config.showEvidence) {
-                    $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData, factID: element.factID });
-                } else {
-                    $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData});
-                }
+            $state.go('main.results', {
+                goalInfo: $scope.goalInfo,
+                responseData: response
+            }, {
+                location: 'replace'
             });
-            $scope.display = 'result';
-
-            if ($scope.tryGoal){
-                focusElementById('reset');
-            } else {
-                focusElementById('done');
-            }
+            // $scope.goalResults = [];
+            // $scope.response = {};
+            // response.result.forEach(function(element) {
+            //     var resultText = ($scope.goalInfo.goalText ? $scope.goalInfo.goalText : $scope.goalInfo.text);
+            //
+            //     var metaData = element.objectMetadata ? element.objectMetadata : '';
+            //
+            //     resultText = resultText.replace(/%O/g, element.object);
+            //     resultText = resultText.replace(/%R/g, element.relationship);
+            //     resultText = resultText.replace(/%S/g, element.subject);
+            //     resultText = resultText.replace(/%C/g, element.certainty);
+            //
+            //     if ($scope.config.showEvidence) {
+            //         $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData, factID: element.factID });
+            //     } else {
+            //         $scope.goalResults.push({text: resultText, cf: element.certainty, meta: metaData});
+            //     }
+            // });
+            // $scope.display = 'result';
+            //
+            // if ($scope.tryGoal){
+            //     focusElementById('reset');
+            // } else {
+            //     focusElementById('done');
+            // }
 
         } else if (angular.isArray(response.result)) {
             $scope.display = 'end';


### PR DESCRIPTION
The scope of this ticket is to create a route that can be accessed to create a pdf of the result of an interaction, as well as to display the results of an interaction to a customer. Initially I thought to create a route for results, to separate it from the rest of the UI flow; however, on reflection that would require a refactor of the buttons that power this flow too (next/prev/reset/done). I'm open to doing this work; though I think it increases the scope of this ticket.

So I've made a common results component which can be either a directive or a route. The latter requires an sid to be passed as a query param, and the API for this is still pending.

I couldn't figure out how to include the config options as part of the route, so if anyone can shed light on this I would be much obliged. At present this is only used to show the (i) link to the decision tree, so isn't necessary for this ticket.

I spoke with Will about testing for this component and we agreed to revisit it should there be time.

Lastly, please don't hold back. All feedback welcome.