### PR TITLE
update: jquery package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ facing release notes.
   *  [Fix] A bug fix
   * [Misc] Other items
 
+## v2.33.0
+  * [Misc]  RB-3905: Update jQuery to 3.4 in response to a potential vulnerability in 3.0 
+
 ## v2.32.0
   * [New]   RB-3820: Add padding to modal inner
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "angular": "1.4.8",
     "browser-sync": "^2.18.13",
     "react": "0.14.0",
-    "jquery": "3.0.x",
+    "jquery": "3.4.x",
     "angular-mocks": "1.4.8",
     "angular-animate": "1.4.8",
     "angular-cookies": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbird-standard-agent",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "publishConfig": {
     "registry": "https://npm.rainbird.ai"
   },


### PR DESCRIPTION
- updates jquery package 

I've looked through the release notes for 3.1, 3.2, 3.3, and 3.4 and it seems it would have no effect on standard agent. 
https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/

Also, I can't see any changes when running locally. May need a quick look over from test team.