### PR TITLE
Feat/rb 4332

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ facing release notes.
   *  [Fix] A bug fix
   * [Misc] Other items
 
+## v2.41.1
+  *  [New]  RB-4332: To allow try/query not to be rate limited, accept a sync token & pass in the start request. 
+
 ## v2.33.0
   * [Misc]  RB-3905: Update jQuery to 3.4 in response to a potential vulnerability in 3.0 
 

--- a/agent.ejs
+++ b/agent.ejs
@@ -10,24 +10,21 @@
     <link href="/components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="/components/angular/angular-csp.css" rel="stylesheet" />
     <link href="/components/font-awesome/css/font-awesome.min.css" rel="stylesheet" />
+    <link href="/components/semantic-ui/dist/semantic.min.css" rel="stylesheet" />
     <link href="/dist/agent.min.css" rel="stylesheet" />
 
+    <script src="/components/jquery/dist/jquery.min.js"></script>
+    <script src="/components/semantic-ui/dist/semantic.js"></script>
+    
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43281177-2"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'UA-43281177-2');
-    </script>
 </head>
 <body>
-    <div ng-app="rbAgent" ng-init="id='<%= id %>'; api='<%= api %>';" ng-strict-di ng-cloak>
+    <div ng-app="rbAgent" ng-init="id='<%= id %>'; api='<%= api %>'; syncToken='<%= syncToken %>';" ng-strict-di ng-cloak>
         <div class="agent-wrapper">
             <ui-view>
             </ui-view>
@@ -41,7 +38,7 @@
     <script src="/components/showdown/dist/showdown.min.js"></script>
     <script src="/components/ng-showdown/dist/ng-showdown.min.js"></script>
     <script src="/components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
-
+    <script src="/dist/angular-semantic-ui.min.js"></script>
     <script src="/dist/agent.min.js"></script>
 </body>
 </html>

--- a/agent.ejs
+++ b/agent.ejs
@@ -15,7 +15,7 @@
 
     <script src="/components/jquery/dist/jquery.min.js"></script>
     <script src="/components/semantic-ui/dist/semantic.js"></script>
-    
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -25,7 +25,7 @@
 </head>
 <body>
     <div ng-app="rbAgent" ng-init="id='<%= id %>'; api='<%= api %>'; syncToken='<%= syncToken %>';" ng-strict-di ng-cloak>
-        <div class="agent-wrapper">
+        <div class="agent-wrapper" style="width: 100%;">
             <ui-view>
             </ui-view>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbird-standard-agent",
-  "version": "2.41.0",
+  "version": "2.41.1-beta.0",
   "publishConfig": {
     "registry": "https://npm.rainbird.ai"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbird-standard-agent",
-  "version": "2.41.1-beta.0",
+  "version": "2.41.1",
   "publishConfig": {
     "registry": "https://npm.rainbird.ai"
   },

--- a/server.js
+++ b/server.js
@@ -18,8 +18,9 @@ app.set('view engine', 'ejs');
 app.get('/', function(req, res) {
     //Contains a demo agent id
     return res.render('agent', {
-        id: 'a2c1ebb9-aa02-4f6b-8e3a-3f21fffb481f',
-        api: 'https://api.rainbird.ai'
+        id: 'dbd8b876-56d6-4db0-acaa-0c250619e26d',
+        api: 'https://api.rainbird.ai',
+        syncToken: undefined,
     });
 });
 

--- a/source/tryGoal/component/tryGoalController.js
+++ b/source/tryGoal/component/tryGoalController.js
@@ -81,7 +81,7 @@ function($scope, $window, agentMemory, $compile, $stateParams, config, GoalAPI, 
     $scope.startGoalContext = function() {
         $scope.display = 'thinking';
 
-        ConfigAPI.getSessionId({ id: $stateParams.id, contextid: contextId}, function(response) {
+        ConfigAPI.getSessionId({ id: $stateParams.id, contextid: contextId, syncToken: $rootScope.syncToken }, function(response) {
             sessionId = response.sessionId;
 
             // Proceed unless the user has since pressed the reset button.

--- a/source/tryGoal/component/tryGoalSpec.js
+++ b/source/tryGoal/component/tryGoalSpec.js
@@ -49,6 +49,7 @@ describe('Try Goal Controller', function() {
 
         beforeEach(inject(
             function ($rootScope, $controller, _$httpBackend_, $stateParams, _ConfigAPI_, _GoalAPI_, _$state_, _$location_) { // jshint ignore:line
+                rootScope = $rootScope;
                 scope = $rootScope.$new();
 
                 $httpBackend = _$httpBackend_;
@@ -60,6 +61,7 @@ describe('Try Goal Controller', function() {
 
                 ctrl = $controller('TryGoalController', {
                     $scope: scope,
+                    $rootScope: rootScope,
                     $stateParams: $stateParams,
                     GoalAPI: GoalAPI,
                     ConfigAPI: ConfigAPI,
@@ -1259,7 +1261,31 @@ describe('Try Goal Controller', function() {
 
             scope.startGoalContext();
 
-            spyOnConfigAPI.should.have.been.calledOnce;
+            const expectedParams = {
+                id: '10000001',
+                contextid: undefined,
+                syncToken: undefined,
+            };
+           
+            expect(spyOnConfigAPI.getCall(0).args[0]).to.deep.equal(expectedParams);
+            spyOnGoalAPI.should.not.have.been.called;
+        });
+
+        it('Agent should call GetSessionID with a syncToken when it is present', function () {
+            var spyOnConfigAPI = sinon.spy(ConfigAPI, 'getSessionId');
+            var spyOnGoalAPI = sinon.spy(GoalAPI, 'startGoal');
+            rootScope.syncToken = '123456abcde';
+            location.url('/agent/10000001');
+
+            scope.startGoalContext();
+
+            const expectedParams = {
+                id: '10000001',
+                contextid: undefined,
+                syncToken: '123456abcde',
+            };
+           
+            expect(spyOnConfigAPI.getCall(0).args[0]).to.deep.equal(expectedParams);
             spyOnGoalAPI.should.not.have.been.called;
         });
 

--- a/source/tryGoal/component/tryGoalSpec.js
+++ b/source/tryGoal/component/tryGoalSpec.js
@@ -1272,8 +1272,8 @@ describe('Try Goal Controller', function() {
         });
 
         it('Agent should call GetSessionID with a syncToken when it is present', function () {
-            var spyOnConfigAPI = sinon.spy(ConfigAPI, 'getSessionId');
-            var spyOnGoalAPI = sinon.spy(GoalAPI, 'startGoal');
+            const spyOnConfigAPI = sinon.spy(ConfigAPI, 'getSessionId');
+            const spyOnGoalAPI = sinon.spy(GoalAPI, 'startGoal');
             rootScope.syncToken = '123456abcde';
             location.url('/agent/10000001');
 

--- a/source/tryGoal/tryGoal_service.js
+++ b/source/tryGoal/tryGoal_service.js
@@ -10,7 +10,7 @@ services.factory('ConfigAPI', ['$resource', function($resource) {
             method:'GET', url: '/goal/info/:goalid/:id', interceptor : {responseError : resourceErrorHandler}
         },
         getSessionId: {
-            method:'GET', url: '/agent/:id/start/contextid', interceptor : {responseError : resourceErrorHandler}
+            method:'GET', url: '/agent/:id/start/contextid/:syncToken', interceptor : {responseError : resourceErrorHandler}
         }
     });
 }]);


### PR DESCRIPTION
Changes to support passing a sync token in the start request.  The sync token is passed into the agent when try/query is loaded.

The agent.ejs & server.js changes below were to support running up this app standalone in order to test.