### PR TITLE
Fix/4894 - Ensure Laserbeak Queries start correctly when a concept instance is defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbird-standard-agent",
-  "version": "2.53.1",
+  "version": "2.54.1-beta.0",
   "publishConfig": {
     "registry": "https://npm.rainbird.ai"
   },

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ app.get('/applications/components/rainbird-analysis-ui/:whyAnalysis', function (
   req,
   res
 ) {
-  res.redirect('https://app.rainbird.ai' + req.originalUrl);
+  res.redirect('https://test-api.rainbird.ai' + req.originalUrl);
 });
 
 app.use('/components', express.static(path.join(__dirname, 'components')));
@@ -21,26 +21,30 @@ app.set('view engine', 'ejs');
 app.get('/', function (req, res) {
   //Contains a demo agent id
   return res.render('agent', {
-    id: '3bea4a38-d91c-4c3c-a7ee-3b5817889caf',
+    id: '01654c11-a842-4b1e-ad98-b20c348fd947',
     api: 'https://test-api.rainbird.ai',
     syncToken: undefined,
-    engine: 'Core',
+    engine: 'Experimental (Beta)',
   });
 });
 
-//Proxies 'config' request to the Rainbird Community environment
+//Proxies 'config' request to the Rainbird Test environment
 app.get('/agent/:id/config', function (req, res) {
   request
     .get('https://test.rainbird.ai/agent/' + req.params.id + '/config')
     .end(function (err, response) {
       res.send(response.body);
     });
-});
-
-//Proxies 'start' request to the Rainbird Community environment
-app.get('/agent/:id/start/contextId', function (req, res) {
-  request
+  });
+  
+  //Proxies 'start' request to the Rainbird Test environment
+  app.get('/agent/:id/start/contextId', function (req, res) {
+    const headers = {};
+    const engine = req.headers['x-rainbird-engine'];
+    if (engine !== undefined) headers['x-rainbird-engine'] = engine;
+    request
     .get('https://test.rainbird.ai/agent/' + req.params.id + '/start')
+    .set(headers)
     .end(function (err, response) {
       res.send(response.body);
     });

--- a/source/agent.js
+++ b/source/agent.js
@@ -80,13 +80,19 @@ agentApp.config([
         controller: "TryGoalController",
         resolve: {
           config: [
-            "ConfigAPI",
-            "$rootScope",
-            function (ConfigAPI, $rootScope) {
-              return ConfigAPI.config({
+            '$q',
+            'ConfigAPI',
+            '$rootScope',
+            function ($q, ConfigAPI, $rootScope) {
+              var deferred = $q.defer();
+              ConfigAPI.config({
                 engine: $rootScope.engine,
                 id: $rootScope.id,
+              }).$promise.then(function (config) {
+                $rootScope.config = config;
+                deferred.resolve(config);
               });
+              return deferred.promise;
             },
           ],
         },


### PR DESCRIPTION
Change to ensure promise containing config is resolved when the /start request is performed when a concept instance is defined within the query config, i.e. not 'user defined'.

The changes in server.js supported testing and is a way to run up an agent without installing into RBApps.